### PR TITLE
Allow users to input new model name

### DIFF
--- a/app/src/main/java/com/example/applayout/LocalAssets/EditFinetuningRelationshipDialog.kt
+++ b/app/src/main/java/com/example/applayout/LocalAssets/EditFinetuningRelationshipDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,7 +34,7 @@ fun EditFinetuningRelationshipDialog(
     onDismiss: () -> Unit,
     models: List<Model>,
     dataset: List<Dataset>,
-    onSubmit: (String, String, Int, Int) -> Unit
+    onSubmit: (String, String, String, Int, Int) -> Unit
 ) {
 
     var selectedModel by remember { mutableStateOf<Model?>(null) }
@@ -42,6 +43,7 @@ fun EditFinetuningRelationshipDialog(
     var expandedDataset by remember { mutableStateOf(false) }
     var numEpochs by remember { mutableStateOf("100") }
     var batchSize by remember { mutableStateOf("10") }
+    var newModelName by remember { mutableStateOf("") }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -106,6 +108,17 @@ fun EditFinetuningRelationshipDialog(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Box {
+                    TextField(
+                        value = newModelName,
+                        onValueChange = { newModelName = it },
+                        label = { Text("New Model File Name") },
+                        placeholder = { Text("Leave blank for a random file name") },
+                        singleLine = true
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Box {
                     NumberInputField(value = numEpochs,
                         labelText = "Number of Epochs",
                         onValueChange = {
@@ -126,6 +139,7 @@ fun EditFinetuningRelationshipDialog(
                         onSubmit(
                             selectedModel!!.uniqueIdentifier,
                             selectedDataset!!.uniqueIdentifier,
+                            newModelName,
                             numEpochs.toInt(),
                             batchSize.toInt()
                         )

--- a/app/src/main/java/com/example/applayout/LocalAssets/LocalAssetsActivity.kt
+++ b/app/src/main/java/com/example/applayout/LocalAssets/LocalAssetsActivity.kt
@@ -446,11 +446,12 @@ fun LocalAssetsScreen(filesDir: File, navController: NavController) {
                 onDismiss = { showFinetuningRelationshipDialog = false },
                 models = uploadedModelListState.value + localModelListState.value,
                 dataset = localDatasetListState.value,
-                onSubmit = { modelFileName, datasetDirName, numEpochs, batchSize ->
+                onSubmit = { modelFileName, datasetDirName, newModelName, numEpochs, batchSize ->
                     coroutineScope.launch(Dispatchers.IO) {
                         Log.d("LocalAssetsScreen", "modelFileName: $modelFileName")
                         Log.d("LocalAssetsScreen", "datasetDirName: $datasetDirName")
-                        val newModel = getNewModel();
+                        Log.d("LocalAssetsScreen", "newModelName: $newModelName")
+                        val newModel = getNewModel(newModelName.ifBlank { null })
                         val trackingResults: HashMap<String, Double> =
                             MetricTracking.doWithTracking {
                                 FinetuneAPI.finetune(

--- a/app/src/main/java/com/example/applayout/LocalAssets/LocalAssetsUtils.kt
+++ b/app/src/main/java/com/example/applayout/LocalAssets/LocalAssetsUtils.kt
@@ -36,10 +36,10 @@ import java.util.zip.ZipInputStream
 
 private const val BASE_URL = "10.96.181.80"
 
-fun getNewModel(): LocalModel {
+fun getNewModel(id: String? = null): LocalModel {
     val randomID = UUID.randomUUID()
     val newModel = LocalModel(
-        uniqueIdentifier = randomID.toString(),
+        uniqueIdentifier = id ?: randomID.toString(),
     )
     return newModel
 }


### PR DESCRIPTION
If the new model name input is blank (empty or whitespace only), we default back to a random generated UUID.